### PR TITLE
Allows for flexible municipality boundaries

### DIFF
--- a/R/AnalysesSecondary.R
+++ b/R/AnalysesSecondary.R
@@ -103,7 +103,7 @@ AnalyseLog <- function() {
 
 
 AggregateAlertsCases <- function(data) {
-  pop <- fhidata::norway_population_current
+  pop <- fd::norway_population()
   current_year <- max(data[, year])
 
   pop_cats <- list(c(0, 10000), c(10000, 100000), c(100000, 6000000))

--- a/R/DataCreationAndValidation.R
+++ b/R/DataCreationAndValidation.R
@@ -9,7 +9,7 @@ GenFakeDataRaw <- function(xmunicipEnd = "municip5054") {
   syndromeOrConsult <- NULL
   age <- NULL
 
-  m <- fhidata::norway_municip_merging
+  m <- fd::norway_municip_merging()
   skeleton <- unique(m[municip_code_current == xmunicipEnd & year <= lubridate::year(lubridate::today()), c("municip_code_original", "year")])
   setnames(skeleton, "municip_code_original", "municip")
 
@@ -49,7 +49,7 @@ ValidateDataRaw <- function(d) {
   n <- VARS$REQ_DATA_RAW[!VARS$REQ_DATA_RAW %in% names(d)]
   if (length(n) > 0) {
     for (i in n) {
-      fhi::DashboardMsg(sprintf("%s not in names(d)", i))
+      fd::msg(sprintf("%s not in names(d)", i))
     }
     return(FALSE)
   }
@@ -58,9 +58,9 @@ ValidateDataRaw <- function(d) {
   n <- names(d)[!names(d) %in% VARS$REQ_DATA_RAW]
   if (sum(!names(d) %in% VARS$REQ_DATA_RAW) > 0) {
     for (i in n) {
-      fhi::DashboardMsg(sprintf("%s not in VARS$REQ_DATA_RAW", i))
+      fd::msg(sprintf("%s not in VARS$REQ_DATA_RAW", i))
     }
-    fhi::DashboardMsg("Variables in names(d) not in VARS$REQ_DATA_RAW", type = "warn")
+    fd::msg("Variables in names(d) not in VARS$REQ_DATA_RAW", type = "warn")
   }
 
   return(TRUE)

--- a/R/std_post_analysis.R
+++ b/R/std_post_analysis.R
@@ -42,11 +42,11 @@ clean_post_analysis <- function(res, stack) {
 
   # adding in extra information
   # add location name
-  res[fhidata::norway_locations_long_current, on = "location_code==location_code", location_name := location_name]
+  res[fd::norway_locations_long(), on = "location_code==location_code", location_name := location_name]
   res[is.na(location_name), location_name := "Norge"]
 
   # add county
-  res[fhidata::norway_locations_current, on = "location_code==municip_code", county_code := county_code]
+  res[fd::norway_locations(), on = "location_code==municip_code", county_code := county_code]
   res[is.na(county_code), county_code := location_code]
 
   # cleaning on small municipalities

--- a/inst/src/RunProcess.R
+++ b/inst/src/RunProcess.R
@@ -16,7 +16,7 @@ if(!fd::config$is_production) Sys.setenv(ONLY_RUN_LATEST_YEAR=TRUE)
 
 fhi::Log("cleanBefore")
 if (!UpdateData()) {
-   fhi::DashboardMsg("Have not run analyses and exiting")
+   fd::msg("Have not run analyses and exiting")
    q(save = "no", status = 21)
 }
 DeleteOldDatasets()


### PR DESCRIPTION
Previously we directly referenced `fhidata::` datasets. Now we reference them via `fd`, which makes a decision as to which `fhidata::` dataset we actually need (based on 2019 or 2020 boundaries).